### PR TITLE
Fix crash on ConnectionError when learner goes offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Necto shit
+training/training
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
This change adds an equal jitter infinite retry to the redis client so instances don't crash if/when the redis server goes offline. It handles ConnectionError and TimeoutError.

The backoff starts with 1 + rand(0, 1) seconds and caps at 10 + rand(0, 10) seconds.